### PR TITLE
setup.py: set long_description_content_type type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
-====
+========
 ipromise
-====
+========
+
 .. image:: https://badge.fury.io/py/ipromise.svg
     :target: https://badge.fury.io/py/ipromise
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     name='ipromise',
     version='0.75',
     description='A Python base class that provides various decorators for specifying promises relating to inheritance.',
+    long_description_content_type='text/x-rst',
     author='Neil Girdhar',
     author_email='mistersheik@gmail.com',
     url='https://github.com/NeilGirdhar/ipromise',


### PR DESCRIPTION
Specify `long_description_content_type='text/x-rst'` so pypi.org
knows how to display the README.rst.

NFC: fix minor error in RST formatting