### PR TITLE
base class overrides must be callable, must exist

### DIFF
--- a/ipromise/overrides.py
+++ b/ipromise/overrides.py
@@ -13,20 +13,30 @@ def overrides(interface_class: Type[Any]) -> Callable[[F], F]:
     def decorated_method(method: F) -> F:
         if hasattr(method, '__must_augment__'):
             raise TypeError(
-                f"{method.__name__} cannot be decorated both must_augment and overrides")
+                f"method {method.__name__} cannot be decorated with both "
+                f"must_augment and overrides")
         if method.__name__ not in vars(interface_class):
-            raise TypeError(
-                f"{method.__name__} not found in interface class {interface_class.__name__}")
+            raise NotImplementedError(
+                f"method {method.__name__} is an override but that "
+                f"attribute is not implemented in interface class "
+                f"{interface_class.__name__}")
         bases_value = getattr(interface_class, method.__name__)
+        if not callable(bases_value):
+            raise TypeError(
+                f"method {method.__name__} is an override "
+                f"but that is implemented as type {type(bases_value).__name__} "
+                f"in base class {type(interface_class).__name__}, expected "
+                f"override of a callable type")
         if hasattr(bases_value, '__overrides_from__'):
             raise TypeError(
-                f"the method {method.__name__} overrides a method in "
+                f"method {method.__name__} overrides a method in "
                 f"the interface class {interface_class.__name__}, "
                 f"but that method overrides from a higher-level interface "
                 f"class {getattr(bases_value, '__overrides_from__')}")
         if getattr(bases_value, "__isabstractmethod__", False):
             raise TypeError(
-                f"{method.__name__} is abstract in interface class {interface_class.__name__}")
+                f"method {method.__name__} is abstract in interface class "
+                f"{interface_class.__name__}")
         method.__overrides_from__ = interface_class  # type: ignore
         return method
 

--- a/test/test_implements.py
+++ b/test/test_implements.py
@@ -16,6 +16,14 @@ class AlsoHasAbstractMethod(AbstractBaseClass):
 
 # Tests from ipromise.py.
 # -----------------------------------------------------------------------------
+def test_implements() -> None:
+    class X(AlsoHasAbstractMethod):
+        @implements(AlsoHasAbstractMethod)
+        def f(self):
+            pass
+    X()
+
+
 def test_implements_interface_is_not_a_base() -> None:
     with pytest.raises(TypeError):
         class X(HasAbstractMethod):


### PR DESCRIPTION
Base class overridden attribute must be callable type.
If not then raise `TypeError`.

Base class must implement the overridden attribute.
If not then raise `NotImplementedError`.

Tangential: tweak nearby error messages in overrides.py.

Add new tests in test_overrides.py and
test_implements.py.

Relates to https://stackoverflow.com/a/54526724/471376